### PR TITLE
php8.0対応

### DIFF
--- a/generator/lib/behavior/DelegateBehavior.php
+++ b/generator/lib/behavior/DelegateBehavior.php
@@ -111,13 +111,14 @@ class DelegateBehavior extends Behavior
                 $relationName = $builder->getFKPhpNameAffix($fk);
             }
             $script .= "
-if (is_callable(array('$ARFQCN', \$name))) {
+\$fullQualifiedClassname = new $ARFQCN;
+if (is_callable([\$fullQualifiedClassname, \$name])) {
     if (!\$delegate = \$this->get$relationName()) {
         \$delegate = new $ARClassName();
         \$this->set$relationName(\$delegate);
     }
 
-    return call_user_func_array(array(\$delegate, \$name), \$params);
+    return call_user_func_array([\$delegate, \$name], \$params);
 }";
         }
 

--- a/generator/lib/builder/om/PHP5PeerBuilder.php
+++ b/generator/lib/builder/om/PHP5PeerBuilder.php
@@ -1200,7 +1200,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
         if ($table->hasCompositePrimaryKey()) {
             $script .= "
 
-        return array(" . implode($pks, ', ') . ");";
+        return array(" . implode(', ', $pks) . ");";
         } else {
             $script .= "
 

--- a/generator/lib/builder/om/QueryBuilder.php
+++ b/generator/lib/builder/om/QueryBuilder.php
@@ -415,10 +415,10 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . "
             }
             $pkType = 'array';
             $pkDescription = "
-                         A Primary key composition: " . '[' . join($colNames, ', ') . ']';
+                         A Primary key composition: " . '[' . join(', ', $colNames) . ']';
             $script .= "
      * <code>
-     * \$obj = \$c->findPk(array(" . join($examplePk, ', ') . "), \$con);";
+     * \$obj = \$c->findPk(array(" . join(', ', $examplePk) . "), \$con);";
         } else {
             $pkType = 'mixed';
             $script .= "

--- a/generator/lib/config/GeneratorConfig.php
+++ b/generator/lib/config/GeneratorConfig.php
@@ -121,7 +121,7 @@ class GeneratorConfig implements GeneratorConfigInterface
         // Basically, we want to turn ?.?.?.sqliteDataSQLBuilder into ?.?.?.SqliteDataSQLBuilder
         $lastdotpos = strrpos($classpath, '.');
         if ($lastdotpos !== false) {
-            $classpath{$lastdotpos + 1} = strtoupper($classpath{$lastdotpos + 1});
+            $classpath[$lastdotpos + 1] = strtoupper($classpath[$lastdotpos + 1]);
         } else {
             // Allows to configure full classname instead of a dot-path notation
             if (class_exists($classpath)) {

--- a/generator/lib/config/QuickGeneratorConfig.php
+++ b/generator/lib/config/QuickGeneratorConfig.php
@@ -62,7 +62,7 @@ class QuickGeneratorConfig implements GeneratorConfigInterface
         }
         foreach ($lines as $line) {
             $line = trim($line);
-            if ($line == "" || $line{0} == '#' || $line{0} == ';') {
+            if ($line == "" || $line[0] == '#' || $line[0] == ';') {
                 continue;
             }
             $pos = strpos($line, '=');

--- a/generator/lib/model/XMLElement.php
+++ b/generator/lib/model/XMLElement.php
@@ -8,8 +8,6 @@
  * @license    MIT License
  */
 
-require_once dirname(__FILE__) . '/VendorInfo.php';
-
 /**
  * An abstract class for elements represented by XML tags (e.g. Column, Table).
  *

--- a/runtime/lib/Propel.php
+++ b/runtime/lib/Propel.php
@@ -731,7 +731,14 @@ class Propel
             }
             $key = constant($key);
 
-            $value = $optiondata['value'];
+            if (!is_array($optiondata))
+            {
+              $value = $optiondata;
+            }
+            else
+            {
+              $value = $optiondata['value'];
+            }
             if (is_string($value) && strpos($value, '::') !== false) {
                 if (!defined($value)) {
                     throw new PropelException("Invalid PDO option/attribute value specified: " . $value);

--- a/runtime/lib/collection/PropelOnDemandCollection.php
+++ b/runtime/lib/collection/PropelOnDemandCollection.php
@@ -148,7 +148,7 @@ class PropelOnDemandCollection extends PropelCollection
         throw new PropelException('The On Demand Collection is read only');
     }
 
-    public function asort()
+    public function asort(int $flags = SORT_REGULAR): void
     {
         throw new PropelException('The On Demand Collection is read only');
     }
@@ -168,7 +168,7 @@ class PropelOnDemandCollection extends PropelCollection
         throw new PropelException('The On Demand Collection does not allow access by offset');
     }
 
-    public function ksort()
+    public function ksort(int $flags = SORT_REGULAR): void
     {
         throw new PropelException('The On Demand Collection is read only');
     }

--- a/runtime/lib/connection/PropelPDO.php
+++ b/runtime/lib/connection/PropelPDO.php
@@ -448,7 +448,7 @@ class PropelPDO extends PDO
      *
      * @return PDOStatement
      */
-    public function query()
+    public function query(string $query, ?int $fetchMode = null, mixed ...$fetchModeArgs)
     {
         if ($this->useDebug) {
             $debug = $this->getDebugSnapshot();

--- a/runtime/lib/parser/yaml/sfYamlInline.php
+++ b/runtime/lib/parser/yaml/sfYamlInline.php
@@ -127,7 +127,7 @@ class sfYamlInline
     if (
       (1 == count($keys) && '0' == $keys[0])
       ||
-      (count($keys) > 1 && array_reduce($keys, create_function('$v,$w', 'return (integer) $v + (integer)$w;'), 0) == count($keys) * (count($keys) - 1) / 2)
+      (count($keys) > 1 && array_reduce($keys, function($v,$w) {return (integer)$v + (integer)$w;}, 0) == count($keys) * (count($keys) - 1) / 2)
     )
     {
       $output = array();

--- a/runtime/lib/query/Join.php
+++ b/runtime/lib/query/Join.php
@@ -537,7 +537,7 @@ class Join
             for ($i = 0; $i < $this->count; $i++) {
                 $conditions [] = $this->getLeftColumn($i) . $this->getOperator($i) . $this->getRightColumn($i);
             }
-            $joinCondition = sprintf('(%s)', implode($conditions, ' AND '));
+            $joinCondition = sprintf('(%s)', implode(' AND ', $conditions));
         } else {
             $joinCondition = '';
             $this->getJoinCondition()->appendPsTo($joinCondition, $params);

--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -523,9 +523,9 @@ class ModelCriteria extends Criteria
      *
      * @throws PropelException
      */
-    public function select($columnArray)
+    public function select(string|array $columnArray)
     {
-        if (!count($columnArray) || $columnArray == '') {
+        if ((is_array($columnArray) && !count($columnArray)) || $columnArray == '') {
             throw new PropelException('You must ask for at least one column');
         }
 

--- a/runtime/lib/util/BasePeer.php
+++ b/runtime/lib/util/BasePeer.php
@@ -397,10 +397,10 @@ class BasePeer
                                 $rawcvt = '';
                                 // parse the $params['raw'] for ? chars
                                 for ($r = 0, $len = strlen($raw); $r < $len; $r++) {
-                                    if ($raw{$r} == '?') {
+                                    if ($raw[$r] == '?') {
                                         $rawcvt .= ':p' . $p++;
                                     } else {
-                                        $rawcvt .= $raw{$r};
+                                        $rawcvt .= $raw[$r];
                                     }
                                 }
                                 $sql .= $rawcvt . ', ';


### PR DESCRIPTION
・静的でないメソッドを静的に呼ぶことができる機能が削除されたためis_callable()が動かなくなっていた
・その他create_function()など互換性がない変更・廃止に対する対応